### PR TITLE
Add owner field for all db kinds

### DIFF
--- a/service/configuration/db/kinds/org.webosports.cdav.account.calendar
+++ b/service/configuration/db/kinds/org.webosports.cdav.account.calendar
@@ -1,6 +1,7 @@
 {
 	"id": "org.webosports.cdav.account.calendar:1",
 	"sync": true,
+	"owner": "org.webosports.cdav.service",
 	"indexes": [
 		{
 			"name": "accountId",

--- a/service/configuration/db/kinds/org.webosports.cdav.account.config
+++ b/service/configuration/db/kinds/org.webosports.cdav.account.config
@@ -1,6 +1,7 @@
 {
 	"id": "org.webosports.cdav.account.config:1",
 	"sync": true,
+	 "owner": "org.webosports.cdav.service",
 	"indexes": [
 		{
 			"name": "accountId",

--- a/service/configuration/db/kinds/org.webosports.cdav.account.contacts
+++ b/service/configuration/db/kinds/org.webosports.cdav.account.contacts
@@ -1,6 +1,7 @@
 {
 	"id": "org.webosports.cdav.account.contacts:1",
 	"sync": true,
+	"owner": "org.webosports.cdav.service",
 	"indexes": [
 		{
 			"name": "accountId",

--- a/service/configuration/db/kinds/org.webosports.cdav.calendar
+++ b/service/configuration/db/kinds/org.webosports.cdav.calendar
@@ -1,6 +1,7 @@
 {
 	"id": "org.webosports.cdav.calendar:1",
 	"sync": false,
+	"owner": "org.webosports.cdav.service",
 	"extends": [
 		"com.palm.calendar:1"
 	],

--- a/service/configuration/db/kinds/org.webosports.cdav.calendarevent
+++ b/service/configuration/db/kinds/org.webosports.cdav.calendarevent
@@ -1,6 +1,7 @@
 {
 	"id": "org.webosports.cdav.calendarevent:1",
 	"sync": false,
+	"owner": "org.webosports.cdav.service",
 	"extends": [
 		"com.palm.calendarevent:1"
 	],

--- a/service/configuration/db/kinds/org.webosports.cdav.contact
+++ b/service/configuration/db/kinds/org.webosports.cdav.contact
@@ -1,6 +1,7 @@
 {
 	"id": "org.webosports.cdav.contact:1",
 	"sync": false,
+	"owner": "org.webosports.cdav.service",
 	"extends": [
 		"com.palm.contact:1"
 	],

--- a/service/configuration/db/kinds/org.webosports.cdav.contactset
+++ b/service/configuration/db/kinds/org.webosports.cdav.contactset
@@ -1,6 +1,7 @@
 {
 	"id": "org.webosports.cdav.contactset:1",
 	"sync": false,
+	"owner": "org.webosports.cdav.service",
 	"indexes": [
 		{
 			"name": "accountId",


### PR DESCRIPTION
configurator complains at startup about the missing owner field:

1970-01-14T03:25:38.425801Z [45] user.err configurator [] Configurator
DB_KIND_CONFIG_ERROR {"file":"/etc/palm/db/kinds/org.webosports.cdav.contactset"} Cannot
determine owner of db kind for /etc/palm/db/kinds/org.webosports.cdav.contactset
1970-01-14T03:25:38.426442Z [45] user.err configurator [] Configurator INVALID_JSON
{"MSGID":"CONFIGURATOR_ERROR", "CAUSE":"The json string is
wrong.","JSON":"{\"config\":\"{\n\t\"id\":
\"org.webosports.cdav.contactset:1\",\n\t\"sync\": false,\n\t\"indexes\":
[\n\t\t{\n\t\t\t\"name\": \"accountId\",\n\t\t\t\"props\": [ ..."}

[...]

Signed-off-by: Simon Busch morphis@gravedo.de
