### PR TITLE
fixed change credentials on LuneOS & legacy 3.x

### DIFF
--- a/service/configuration/db/permissions/org.webosports.cdav.account.config
+++ b/service/configuration/db/permissions/org.webosports.cdav.account.config
@@ -9,5 +9,16 @@
             "delete": "allow",
             "update": "allow"
         }
+    },
+    {
+        "type": "db.kind",
+        "object": "org.webosports.cdav.account.config:1",
+        "caller": "com.palm.*",
+        "operations": {
+            "read": "allow",
+            "create": "allow",
+            "delete": "allow",
+            "update": "allow"
+        }
     }
 ]

--- a/service/javascript/assistants/checkcredentialsassistant.js
+++ b/service/javascript/assistants/checkcredentialsassistant.js
@@ -20,6 +20,9 @@ checkCredentialsAssistant.prototype.run = function (outerfuture) {
         password: args.password,
         authToken: base64Auth
     };
+    if (args.oauth) {
+        this.userAuth = args.oauth;
+    }
 
     if (args && args.config) {
         if (!url) {
@@ -85,7 +88,7 @@ checkCredentialsAssistant.prototype.run = function (outerfuture) {
     });
 
     future.then(this, function credentialsCheckCB() {
-        var result = checkResult(future), authToken, msg, exception, returnCode;
+        var result = checkResult(future), msg, exception, returnCode;
         // Check if we are getting a good return code for success
         if (result.returnValue === true) {
             // Pass back credentials and config (username/password/url);
@@ -95,10 +98,8 @@ checkCredentialsAssistant.prototype.run = function (outerfuture) {
 
             if (args.accountId) {
                 Log.log("Had account id => this is change credentials call, update config object");
-                authToken = "Basic " + Base64.encode(args.username + ":" + args.password);
-                this.client.userAuth = {"user": args.username, "password": args.password, "authToken": authToken};
 
-                future.nest(KeyStore.putKey(args.accountId, this.client.userAuth));
+                future.nest(KeyStore.putKey(args.accountId, this.userAuth));
             } else {
             //send results back to UI:
                 buildResult();


### PR DESCRIPTION
Needed to add account app to permissions for account config
in order to get URL from db.

Also changed oauth app, stores new oauth tokens. Although this
should not be necessary unless user revokes access to app.

Not sure what happens if user changes username, because
webOS does not really support this. Maybe webOS will still
show old username, but C+Dav service should use new
username internally, so everything should still work out fine.

In theory user can also change url & account name.

Fixes issues #51 and #50 
