### PR TITLE
Garfonso/work

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+0.3.22:
+	o fix for account creation and URL resolving that required username in URL.
+2015-02-24: Achim Königs <garfonso@mobo.info>
+
 0.3.21:
 	o hot-fix for account creation with known-server-templates. Accounts created with 0.3.20 might stop working after this version. So please consider recreation if you created an account with 0.3.20.
 2015-02-23: Achim Königs <garfonso@mobo.info>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+0.3.21:
+	o hot-fix for account creation with known-server-templates. Accounts created with 0.3.20 might stop working after this version. So please consider recreation if you created an account with 0.3.20.
+2015-02-23: Achim Königs <garfonso@mobo.info>
+
 0.3.20:
 	o changed reaction to connection close, will wait if something happens.
 	o improved app to select urlSchems during account creation.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+0.3.23:
+	o App: stats and status display improvements
+	o refresh Auth on 401 errors for OAuth and Digest Auth
+	o reworked ignoreSSLCertificateErrors
+	o Prevent unnecessary downloads of etags if we see unrecoverable download errors for single items like 404.
+2015-02-25: Achim Königs <garfonso@mobo.info>
+
 0.3.22:
 	o fix for account creation and URL resolving that required username in URL.
 2015-02-24: Achim Königs <garfonso@mobo.info>

--- a/README.md
+++ b/README.md
@@ -3,20 +3,23 @@ Summary
 
 Node.js service to provide synergy connector for CardDav and CalDav.
 
-In its current status it is partly functional.
+In its current status it is quite functional.
 
 Currently working:
-* One way sync of contacts and calendar entries from server
+* Two way sync of contacts and calendar entries
 * Periodic sync
+* Sync on local changes
+* OAuth authorization (currently only Google)
+* MDigest authorization
+* Retries for downloads and uploads after failed syncs
+* Auto discovery of c+dav URLs or setting URL using a list of known servers
+* An app to show some statistics and sync status
 
 Roadmap would look roughly like this:
-* Implement two way sync
 * Add tasks support via calDAV VTODO items
+* Improve VCard and VEVENT compability
 
 No timeline is given for this. Pull requests are always welcome.
-
-
-
 
 Icon source:
 http://www.intridea.com/blog/2010/6/1/authbuttons-free-and-open-source-web-logo-icons

--- a/accounts-google-mojo/account-template.json
+++ b/accounts-google-mojo/account-template.json
@@ -29,7 +29,7 @@
 	},
 	"config": {
 		"name": "Google C+DAV",
-		"urlScheme": 1,
+		"urlScheme": "google",
 		"url": "https://www.googleapis.com/caldav/v2"
 	},
 	"capabilityProviders": [

--- a/accounts-google/account-template.json
+++ b/accounts-google/account-template.json
@@ -29,7 +29,7 @@
 	},
 	"config": {
 		"name": "Google C+DAV",
-		"urlScheme": 1,
+		"urlScheme": "google",
 		"url": "https://www.googleapis.com/caldav/v2"
 	},
 	"capabilityProviders": [

--- a/accounts-icloud/account-template.json
+++ b/accounts-icloud/account-template.json
@@ -23,7 +23,7 @@
 	},
 	"config": {
 		"name": "iCloud",
-		"urlScheme": 0,
+		"urlScheme": "icloud",
 		"url": "https://p02-contacts.icloud.com"
 	},
 	"capabilityProviders": [

--- a/accounts-yahoo/account-template.json
+++ b/accounts-yahoo/account-template.json
@@ -23,7 +23,7 @@
 	},
 	"config": {
 		"name": "Yahoo",
-		"urlScheme": 2,
+		"urlScheme": "yahoo",
 		"url": "https://carddav.address.yahoo.com"
 	},
 	"capabilityProviders": [

--- a/app-enyo/CrossAppTarget/CrossAppTarget.js
+++ b/app-enyo/CrossAppTarget/CrossAppTarget.js
@@ -102,12 +102,13 @@ enyo.kind({
 		console.error("<<<<<<<<<<<<<<<<<<<< create");
 
 		//setup picker items:
-		var items = [{caption: $L("Manual setup"), value: -1}];
+		var items = [{caption: $L("Manual setup"), value: "manualsetup"}];
 		if (UrlSchemes && UrlSchemes.urlSchemes) {
-			UrlSchemes.urlSchemes.forEach(function (scheme, index) {
+			Object.keys(UrlSchemes.urlSchemes).forEach(function (schemeKey) {
+				var scheme = UrlSchemes.urlSchemes[schemeKey];
 				if (scheme.name) {
-					console.log("Adding " + scheme.name + " with index " + index);
-					items.push({ caption: scheme.name, value: index });
+					console.log("Adding " + scheme.name + " with index " + schemeKey);
+					items.push({ caption: scheme.name, value: schemeKey });
 				}
 			}.bind(this));
 		}
@@ -116,7 +117,7 @@ enyo.kind({
 		this.$.picker.setValue(items[0].value);
 	},
 	serverPicked: function () {
-		if (this.$.picker.getValue() >= 0) {
+		if (this.$.picker.getValue() !== "manualsetup") {
 			this.urlScheme = this.$.picker.getValue();
 			var urlScheme = UrlSchemes.urlSchemes[this.urlScheme];
 			if (urlScheme.needPrefix) { //do we need an url at all?

--- a/app-enyo/source/CDavApp.js
+++ b/app-enyo/source/CDavApp.js
@@ -80,7 +80,7 @@ enyo.kind({
 				{name: "numEvents", content: $L("Number of events: tbd")}
 			]},
 			{ kind: "RowGroup", caption: $L("Status"), components: [
-				{name: "running", content: $L("Sync not running."), showing: false },
+				{name: "running", content: $L("Sync not running.") },
 				{name: "lastMessage", content: $L("Status: ") },
 				{name: "numDownloaded", content: $L("Downloads: ") },
 				{name: "numUploaded", content: $L("Uploads: ") }
@@ -196,9 +196,13 @@ enyo.kind({
 		this.$.numEvents.setContent($L("Number of events: tbd"));
 
 		this.$.running.setContent($L("Sync is not running."));
-		this.$.lastMessage.setContent($L("Status: "));
-		this.$.numDownloaded.setContent($L("Downloads: "));
-		this.$.numUploaded.setContent($L("Uploads: "));
+		if (this.lastStatus) {
+			this.$.lastMessage.setContent($L("Last Status: ") + this.lastStatus);
+		} else {
+			this.$.lastMessage.setContent($L("Status: "));
+		}
+		this.$.numDownloaded.setContent($L("Downloads: No downloads"));
+		this.$.numUploaded.setContent($L("Uploads: No uploads"));
 	},
 	gotConactNumbers: function (inSender, inResponse) {
 		if (inResponse) {
@@ -220,6 +224,7 @@ enyo.kind({
 	},
 	accountChanged: function () {
 		console.log("accountChanged to " + this.$.picker.getValue());
+		this.lastStatus = "";
 		this.resetStats();
 		this.getStats();
 		this.getStatus();
@@ -260,6 +265,7 @@ enyo.kind({
 						stat = status[kind];
 						if (stat.status) {
 							this.$.lastMessage.setContent("Status: " + stat.status);
+							this.lastStatus = stat.status;
 						}
 						if (stat.uploadTotal) {
 							this.$.numDownloaded.setContent("Uploading " + (stat.uploadsDone || 0) + " of " + stat.uploadTotal);
@@ -277,9 +283,13 @@ enyo.kind({
 
 		} else {
 			this.$.running.setContent($L("Sync is not running."));
-			this.$.lastMessage.setContent($L("Status: "));
-			this.$.numDownloaded.setContent($L("Downloads: "));
-			this.$.numUploaded.setContent($L("Uploads: "));
+			if (this.lastStatus) {
+				this.$.lastMessage.setContent($L("Last Status: ") + this.lastStatus);
+			} else {
+				this.$.lastMessage.setContent($L("Status: "));
+			}
+			this.$.numDownloaded.setContent($L("Downloads: No downloads"));
+			this.$.numUploaded.setContent($L("Uploads: No uploads"));
 		}
 	}
 

--- a/app-enyo/source/CDavApp.js
+++ b/app-enyo/source/CDavApp.js
@@ -188,6 +188,8 @@ enyo.kind({
 	endAcitivity: function () {
 		this.$.spinner.hide();
 		this.$.buttonContainer.show();
+
+		this.getStats();
 	},
 
 	resetStats: function () {
@@ -205,21 +207,27 @@ enyo.kind({
 		this.$.numUploaded.setContent($L("Uploads: No uploads"));
 	},
 	gotConactNumbers: function (inSender, inResponse) {
-		if (inResponse) {
+		if (inResponse && inResponse.count !== undefined) {
 			console.log("Got contactNumbers: " + JSON.stringify(inResponse));
 			this.$.numContacts.setContent($L("Number of contacts: ") + inResponse.count);
+		} else if (inResponse.fired) {
+			this.getStats();
 		}
 	},
 	gotCalendarNumbers: function (inSender, inResponse) {
-		if (inResponse) {
+		if (inResponse && inResponse.count !== undefined) {
 			console.log("Got calendarNumbers: " + JSON.stringify(inResponse));
 			this.$.numCalendars.setContent($L("Number of calendars: ") + inResponse.count);
+		} else if (inResponse.fired) {
+			this.getStats();
 		}
 	},
 	gotCalendarEventNumbers: function (inSender, inResponse) {
-		if (inResponse) {
+		if (inResponse && inResponse.count !== undefined) {
 			console.log("Got calendarEventNumbers: " + JSON.stringify(inResponse));
 			this.$.numEvents.setContent($L("Number of events: ") + inResponse.count);
+		} else if (inResponse.fired) {
+			this.getStats();
 		}
 	},
 	accountChanged: function () {

--- a/app/app/assistants/account-setup-assistant.js
+++ b/app/app/assistants/account-setup-assistant.js
@@ -26,16 +26,17 @@ AccountSetupAssistant.prototype.setup = function () {
 	}
 
 	this.knownServersModel = {
-		value: -1,
+		value: "manualsetup",
 		choices: [
-			{ label: $L("Manual setup"), value: -1 }
+			{ label: $L("Manual setup"), value: "manualsetup" }
 		]
 	};
 
 	if (UrlSchemes && UrlSchemes.urlSchemes) {
-		UrlSchemes.urlSchemes.forEach(function (scheme, index) {
-			if (scheme.name) {
-				this.knownServersModel.choices.push({ label: scheme.name, value: index });
+		Object.keys(UrlSchemes.urlSchemes).forEach(function (schemeKey) {
+			var scheme = UrlSchemes.urlSchemes[schemeKey];
+			if (!scheme.hidden) {
+				this.knownServersModel.choices.push({ label: scheme.name, value: schemeKey });
 			}
 		}.bind(this));
 	}
@@ -67,7 +68,7 @@ AccountSetupAssistant.prototype.setup = function () {
 };
 
 AccountSetupAssistant.prototype.handleServerSelect = function () {
-	if (this.knownServersModel.value >= 0) {
+	if (this.knownServersModel.value !== "manualsetup") {
 		var urlScheme = UrlSchemes.urlSchemes[this.knownServersModel.value];
 		if (urlScheme.needPrefix) { //do we need an url at all?
 			this.urlWidget.show();

--- a/app/app/assistants/account-setup-google-assistant.js
+++ b/app/app/assistants/account-setup-google-assistant.js
@@ -128,7 +128,6 @@ AccountSetupGoogleAssistant.prototype.tokenCB = function (response) {
 };
 
 AccountSetupGoogleAssistant.prototype.nameCB = function (credbody, response) {
-	debug("Blargh?");
 	try {
 		var body, i, template = this.params.initialTemplate;
 		//debug("Get-Token call came back: " + JSON.stringify(response));

--- a/app/app/assistants/check-status-assistant.js
+++ b/app/app/assistants/check-status-assistant.js
@@ -43,13 +43,15 @@ CheckStatusAssistant.prototype.startSync = function () {
 			this.syncing = false;
 			this.button.mojo.deactivate();
 			this.startSyncModel.disabled = false;
-			this.controller.modelChanged(this.startSyncModel);
+			if (this.controller) { //otherwise scene was already popped.
+				this.controller.modelChanged(this.startSyncModel);
 
-			this.controller.showAlertDialog({
-				title: "Sync finished",
-				message: "Sync came back with result: " + JSON.stringify(result),
-				choices: [{label: $L("OK"), value: "OK"}]
-			});
+				this.controller.showAlertDialog({
+					title: "Sync finished",
+					message: "Sync came back with result: " + JSON.stringify(result),
+					choices: [{label: $L("OK"), value: "OK"}]
+				});
+			}
 		});
 	}
 };

--- a/app/app/assistants/check-status-assistant.js
+++ b/app/app/assistants/check-status-assistant.js
@@ -46,6 +46,10 @@ CheckStatusAssistant.prototype.startSync = function () {
 			if (this.controller) { //otherwise scene was already popped.
 				this.controller.modelChanged(this.startSyncModel);
 
+				this.getNumobjects("org.webosports.cdav.contact:1", this.setNumContacts.bind(this));
+				this.getNumobjects("org.webosports.cdav.calendar:1", this.setNumCalendars.bind(this));
+				this.getNumobjects("org.webosports.cdav.calendarevent:1", this.setNumEvents.bind(this));
+
 				this.controller.showAlertDialog({
 					title: "Sync finished",
 					message: "Sync came back with result: " + JSON.stringify(result),

--- a/app/app/assistants/check-status-assistant.js
+++ b/app/app/assistants/check-status-assistant.js
@@ -1,6 +1,6 @@
 //JSLint options:
 /*jslint browser: true */
-/*global $L, Mojo, AppAssistant, console, PalmCall, UrlSchemes, log */
+/*global $L, Mojo, AppAssistant, console, PalmCall, log */
 function CheckStatusAssistant(params) {
 	"use strict";
 	if (params) {

--- a/app/app/assistants/check-status-assistant.js
+++ b/app/app/assistants/check-status-assistant.js
@@ -99,7 +99,7 @@ CheckStatusAssistant.prototype.getNumobjects = function (kind, callback) {
 			if (result.fired) {
 				console.log("Watch fired, get items again.");
 				return this.getNumobjects(kind, callback); //should nest futures and prevents our then.
-			} else if (result.count) {
+			} else if (result.count !== undefined) {
 				console.log("Count result");
 				callback(result.count);
 			}

--- a/package/packageinfo.json
+++ b/package/packageinfo.json
@@ -2,7 +2,7 @@
 	"id": "org.webosports.cdav",
 	"package_format_version": 2,
 	"loc_name": "C+DAV synergy connector",
-	"version": "0.3.22",
+	"version": "0.3.23",
 	"vendor": "WebOS Ports - Stefan Schmidt",
 	"vendorurl": "www.webos-ports.org",
 	"app": "org.webosports.cdav.app",

--- a/package/packageinfo.json
+++ b/package/packageinfo.json
@@ -2,7 +2,7 @@
 	"id": "org.webosports.cdav",
 	"package_format_version": 2,
 	"loc_name": "C+DAV synergy connector",
-	"version": "0.3.20",
+	"version": "0.3.21",
 	"vendor": "WebOS Ports - Stefan Schmidt",
 	"vendorurl": "www.webos-ports.org",
 	"app": "org.webosports.cdav.app",

--- a/package/packageinfo.json
+++ b/package/packageinfo.json
@@ -2,7 +2,7 @@
 	"id": "org.webosports.cdav",
 	"package_format_version": 2,
 	"loc_name": "C+DAV synergy connector",
-	"version": "0.3.21",
+	"version": "0.3.22",
 	"vendor": "WebOS Ports - Stefan Schmidt",
 	"vendorurl": "www.webos-ports.org",
 	"app": "org.webosports.cdav.app",

--- a/service/javascript/assistants/checkcredentialsassistant.js
+++ b/service/javascript/assistants/checkcredentialsassistant.js
@@ -40,7 +40,7 @@ checkCredentialsAssistant.prototype.run = function (outerfuture) {
 		Log.debug("Have account id => this is change credentials call, get config object from db.");
 		future.nest(searchAccountConfig(args));
 	} else {
-		future.result = {returnValue: true,  config: {url: url, urlScheme: urlScheme, name: name}};
+		future.result = {returnValue: true,  config: {url: url, urlScheme: urlScheme, name: name, username: args.username}};
 	}
 
 	//build result and send it back to UI.
@@ -72,7 +72,7 @@ checkCredentialsAssistant.prototype.run = function (outerfuture) {
 
 			urlScheme = urlScheme || this.config.urlScheme;
 			url = url || this.config.url;
-			userAuth.username = this.config.username;
+			userAuth.username = userAuth.username || this.config.username;
 			if (scheme && !scheme.oauth) {
 				Log.debug("Overwiting authToken with username from db: ", userAuth.username);
 				userAuth.authToken = "Basic " + Base64.encode(userAuth.username + ":" + args.password);

--- a/service/javascript/assistants/checkcredentialsassistant.js
+++ b/service/javascript/assistants/checkcredentialsassistant.js
@@ -99,7 +99,17 @@ checkCredentialsAssistant.prototype.run = function (outerfuture) {
 		}
 
 		// Test basic authentication. If this fails username and or password is wrong
-		future.nest(AuthManager.checkAuth(userAuth, path, -1));
+		future.nest(
+			AuthManager.checkAuth(
+				userAuth,
+				path,
+				-1,
+				{
+					userAuth: userAuth,
+					ignoreSSLCertificateErrors: this.config.ignoreSSLCertificateErrors
+				}
+			)
+		);
 	});
 
 	future.then(this, function credentialsCheckCB() {

--- a/service/javascript/assistants/checkcredentialsassistant.js
+++ b/service/javascript/assistants/checkcredentialsassistant.js
@@ -81,7 +81,7 @@ checkCredentialsAssistant.prototype.run = function (outerfuture) {
 		scheme = UrlSchemes.urlSchemes[urlScheme];
 
 		//use forced scheme to resolve here, otherwise search strings in URL.
-		url = UrlSchemes.resolveURL(url, userAuth.username, "checkCredentials", urlScheme);
+		url = UrlSchemes.resolveURL(url, userAuth.username, "checkCredentials", urlScheme) || url;
 
 		if (url) {
 			path = url;
@@ -99,7 +99,7 @@ checkCredentialsAssistant.prototype.run = function (outerfuture) {
 		}
 
 		// Test basic authentication. If this fails username and or password is wrong
-		future.nest(AuthManager.checkAuth(userAuth, path));
+		future.nest(AuthManager.checkAuth(userAuth, path, -1));
 	});
 
 	future.then(this, function credentialsCheckCB() {

--- a/service/javascript/assistants/discoveryassistant.js
+++ b/service/javascript/assistants/discoveryassistant.js
@@ -32,11 +32,11 @@ DiscoveryAssistant.prototype.run = function (outerFuture) {
 	return outerFuture;
 };
 
-DiscoveryAssistant.prototype.resolveHome = function (params, username, type) {
+DiscoveryAssistant.prototype.resolveHome = function (params, username, type, urlSchemeKey) {
 	"use strict";
 	var future = new Future(), home;
 
-	home = UrlSchemes.resolveURL(params.originalUrl, username, type);
+	home = UrlSchemes.resolveURL(params.originalUrl, username, type, urlSchemeKey);
 	if (home) {
 		Log.log("Could resolve ", type, " home from known URL schemes, get folders from there");
 		params.path = home;
@@ -87,7 +87,7 @@ DiscoveryAssistant.prototype.processAccount = function (args, config) {
 			config.urlScheme = args.urlScheme;
 		}
 
-		//if have urlScheme that does not need url, no useful url is stored in db. So use checkCredentials url as home here.
+		//if have urlScheme that does not need url, no usefull url is stored in db. So use checkCredentials url as home here.
 		if (config.urlScheme && UrlSchemes.urlSchemes[config.urlScheme] && !UrlSchemes.urlSchemes[config.urlScheme].needPrefix) {
 			config.url = UrlSchemes.resolveURL(config.url, config.username, "checkCredentials", config.urlScheme);
 		}
@@ -114,7 +114,7 @@ DiscoveryAssistant.prototype.processAccount = function (args, config) {
 		};
 
 		params.cardDav = false;
-		future.nest(this.resolveHome(params, config.username, "calendar"));
+		future.nest(this.resolveHome(params, config.username, "calendar", config.urlScheme));
 
 		future.then(this, function calendarResolveCB() {
 			var result = checkResult(future);
@@ -125,7 +125,7 @@ DiscoveryAssistant.prototype.processAccount = function (args, config) {
 			}
 
 			params.cardDav = true;
-			future.nest(this.resolveHome(params, config.username, "contact"));
+			future.nest(this.resolveHome(params, config.username, "contact", config.urlScheme));
 		});
 
 		future.then(this, function contactResolveCB() {

--- a/service/javascript/assistants/discoveryassistant.js
+++ b/service/javascript/assistants/discoveryassistant.js
@@ -110,7 +110,9 @@ DiscoveryAssistant.prototype.processAccount = function (args, config) {
 		params = {
 			path: config.url,
 			userAuth: this.client.userAuth,
-			originalUrl: config.url
+			originalUrl: config.url,
+			ignoreSSLCertificateErrors: this.client.config.ignoreSSLCertificateErrors,
+			authCallback: this.client.config.authCallback
 		};
 
 		params.cardDav = false;

--- a/service/javascript/assistants/serviceassistant.js
+++ b/service/javascript/assistants/serviceassistant.js
@@ -166,6 +166,12 @@ var ServiceAssistant = Transport.ServiceAssistantBuilder({
 
 					future.then(this, function checkAuthCB() {
 						var result = checkResult(future);
+						if (typeof result.authCallback === "function") {
+							//under some circumstance we might lose auth during sync (i.e. oauth needs refresh)
+							 //if so, we will do the AuthCheck again for this servers on 401 errors.
+							this.config.authCallback = result.authCallback;
+						}
+
 						if (result.credentials) { //need to store changed credentials.
 							//fs.writeFile("/media/internal/.org.webosports.cdav.service.keystore-debug", "Time: " + (new Date()) + "\nService Version: " + PackageVersion + "\nMethod: " + launchConfig.name + "\nNewKeyValue: " + JSON.stringify(this.userAuth) + "\nParams: " + JSON.stringify(launchArgs) + "\nOldKey: " + JSON.stringify(result));
 							KeyStore.putKey(this.accountId, this.userAuth).then(this, function putOAuthCB(putKey) {

--- a/service/javascript/assistants/serviceassistant.js
+++ b/service/javascript/assistants/serviceassistant.js
@@ -107,10 +107,6 @@ var ServiceAssistant = Transport.ServiceAssistantBuilder({
 					this.config = result.config;
 				}
 
-				if (this.config.ignoreSSLCertificateErrors && this.config.url) {
-					httpClient.setIgnoreSSLCertificateErrorsForHost(this.config.url, true);
-				}
-
 				future.nest(iCal.initialize());
 			});
 
@@ -155,7 +151,17 @@ var ServiceAssistant = Transport.ServiceAssistantBuilder({
 						//Log.debug("------------->Got Key", result);
 						this.userAuth = result.credentials;
 
-						future.nest(AuthManager.checkAuth(this.userAuth, this.config.url));
+						future.nest(
+							AuthManager.checkAuth(
+								this.userAuth,
+								this.config.url,
+								this.config.urlScheme,
+								{
+									userAuth: this.userAuth,
+									ignoreSSLCertificateErrors: this.config.ignoreSSLCertificateErrors
+								}
+							)
+						);
 					});
 
 					future.then(this, function checkAuthCB() {

--- a/service/javascript/assistants/syncassistant.js
+++ b/service/javascript/assistants/syncassistant.js
@@ -380,6 +380,7 @@ var SyncAssistant = Class.create(Sync.SyncCommand, {
 			path: path,
 			blacklist: this.blacklist,
 			ignoreSSLCertificateErrors: this.client.config.ignoreSSLCertificateErrors,
+			authCallback: this.client.config.authCallback
 		};
 
 		this.SyncKey.prepare(kindName, state);

--- a/service/javascript/assistants/syncassistant.js
+++ b/service/javascript/assistants/syncassistant.js
@@ -375,7 +375,12 @@ var SyncAssistant = Class.create(Sync.SyncCommand, {
 			this.blacklist = [];
 		}
 
-		this.params = { userAuth: this.client.userAuth, path: path, blacklist: this.blacklist };
+		this.params = {
+			userAuth: this.client.userAuth,
+			path: path,
+			blacklist: this.blacklist,
+			ignoreSSLCertificateErrors: this.client.config.ignoreSSLCertificateErrors,
+		};
 
 		this.SyncKey.prepare(kindName, state);
 

--- a/service/javascript/urlschemes.js
+++ b/service/javascript/urlschemes.js
@@ -12,27 +12,33 @@ var UrlSchemes = {
 	//replace URL for checkCredentials, caldav and carddav with known URLs.
 	//issue: some require user specific parts in URL, replace them on useage...
 	//       if a replacement is required more than once, change function!
-	urlSchemes: [
-		//indices for iCloud, Google and Yahoo have to be fixed.
-		{
+	urlSchemes: {
+		//keys should never change, otherwise old accounts will break.
+		//not allowed key: "manualsetup".
+		//keys should be lowercase and without special chars. Usually they include domain names. Like fruux.com => fruuxcom
+		//Exception are services with multiple domains (i.e. google, yahoo)
+		icloud: {
 			//contact & calendar hostname vary for each user, it seems.
 			keys:              ["icloud.com"],
+			hidden:            true,
 			checkCredentials:  "https://p02-contacts.icloud.com:443"
 		},
-		{
+		google: {
 			oauth:             true,
+			hidden:            true,
 			keys:              [".googleapis.", ".google."],
 			calendar:          "https://www.googleapis.com:443/caldav/v2/%USERNAME%/",
 			contact:           "https://www.googleapis.com:443/carddav/v1/principals/%USERNAME%/lists/",
 			checkCredentials:  "https://www.googleapis.com:443/.well-known/carddav"
 		},
-		{
+		yahoo: {
 			keys:              ["yahoo."],
+			hidden:            true,
 			calendar:          "https://caldav.calendar.yahoo.com/dav/%USERNAME%/Calendar/",
 			contact:           "https://carddav.address.yahoo.com/dav/%USERNAME%/",
 			checkCredentials:  "https://caldav.calendar.yahoo.com/dav/"
 		},
-		{
+		owncloud: {
 			name:              "ownCloud",
 			keys:              ["/owncloud/", "cloudu.de"],
 			needPrefix:        true,
@@ -41,7 +47,7 @@ var UrlSchemes = {
 			contact:           "%URL_PREFIX%remote.php/carddav/addressbooks/%USERNAME%/",
 			checkCredentials:  "%URL_PREFIX%remote.php/caldav"
 		},
-		{
+		egroupware: {
 			name:              "eGroupware",
 			keys:              ["/egroupware/"],
 			needPrefix:        true,
@@ -52,7 +58,7 @@ var UrlSchemes = {
 				preventDuplicateCalendarEntries: true
 			}
 		},
-		{
+		sogo: {
 			name:              "SOGo",
 			keys:              ["/SOGo/"],
 			needPrefix:        true,
@@ -60,7 +66,7 @@ var UrlSchemes = {
 			contact:           "%URL_PREFIX%dav/%USERNAME%/Contacts/",
 			checkCredentials:  "%URL_PREFIX%dav/%USERNAME%/"
 		},
-		{
+		sabredav: {
 			name:              "sabre/dav",
 			keys:              ["/sabredav/"],
 			needPrefix:        true,
@@ -68,57 +74,57 @@ var UrlSchemes = {
 			contact:           "%URL_PREFIX%addressbookserver.php/addressbooks/%USERNAME%/",
 			checkCredentials:  "%URL_PREFIX%calendarserver.php/calendars/%USERNAME%/default/"
 		},
-		{
+		fruuxcom: {
 			name:              "fruux.com",
 			keys:              [".fruux.com"],
 			checkCredentials:  "https://dav.fruux.com/"
 		},
-		{ //GoDaddy
+		godaddy: { //GoDaddy
 			name:              "GoDaddy",
 			keys:              [".secureserver.net/"],
 			calendar:          "https://caldav.secureserver.net/principals/users/",
 			checkCredentials:  "https://caldav.secureserver.net/principals/users/"
 		},
-		{ //Meeting Maker Server
+		meetingmaker: { //Meeting Maker Server
 			name:              "Meeting Maker",
 			keys:              ["/mmcaldav/"],
 			needPrefix:        true,
 			calendar:          "%URL_PREFIX%dav/%USERNAME%/",
 			checkCredentials:  "%URL_PREFIX%dav/%USERNAME%/"
 		},
-		{
+		foliofabasoftcom: {
 			keys:              [".folio.fabasoft.com"],
 			calendar:          "https://at.folio.fabasoft.com/folio/caldav/",
 			checkCredentials:  "https://at.folio.fabasoft.com/folio/caldav/"
 		},
-		{
+		terminlandde: {
 			name:              "Terminland.de",
 			keys:              ["terminland.de"],
 			calendar:          "https://www.terminland.de/%USERNAME%/dav/",
 			checkCredentials:  "https://www.terminland.de/%USERNAME%/dav/"
 		},
-		{
+		mykolabcom: {
 			name:              "mykolab.com",
 			keys:              ["mykolab.com"],
 			calendar:          "https://caldav.mykolab.com/calendars/%USERNAME%%40mykolab.com/",
 			contact:           "https://carddav.mykolab.com/addressbooks/%USERNAME%%40mykolab.com/",
 			checkCredentials:  "https://caldav.mykolab.com/calendars/%USERNAME%%40mykolab.com/"
 		},
-		{
+		mailde: {
 			name:              "Mail.de",
 			keys:              [".mail.de"],
 			calendar:          "https://kalender.mail.de/calendars/%USERNAME%/",
 			contact:           "https://adressbuch.mail.de/addressbooks/%USERNAME%/",
 			checkCredentials:  "https://kalender.mail.de/calendars/%USERNAME%/"
 		},
-		{
+		posteode: {
 			name:              "Posteo.de",
 			keys:              ["posteo.de"],
 			calendar:          "https://posteo.de:8443/calendars/%USERNAME%/",
 			contact:           "https://posteo.de:8843/addressbooks/%USERNAME%/",
 			checkCredentials:  "https://posteo.de:8443/calendars/"
 		},
-		{
+		horde: {
 			name:              "Horde",
 			keys:              ["/horde/"],
 			needPrefix:        true,
@@ -126,43 +132,43 @@ var UrlSchemes = {
 			contact:           "%URL_PREFIX%rpc.php/principals/%USERNAME%/",
 			checkCredentials:  "%URL_PREFIX%rpc.php/calendars/%USERNAME%/"
 		},
-		{
+		telnetbe: {
 			name:              "Telnet.be",
 			keys:              [".telnet.be"],
 			calendar:          "https://mail.telenet.be/dav/%USERNAME%/",
 			checkCredentials:  "https://mail.telenet.be/dav/"
 		},
-		{
+		webde: {
 			name:              "Web.de",
 			keys:              [".web.de"],
 			calendar:          "https://caldav.web.de/%USERNAME%/",
 			checkCredentials:  "https://caldav.web.de/"
 		},
-		{
+		yandexru: {
 			name:              "Yandex.ru",
 			keys:              [".yandex.ru"],
 			calendar:          "https://caldav.yandex.ru/",
 			contact:           "https://carddav.yandex.ru/",
 			checkCredentials:  "https://caldav.yandex.ru/"
 		},
-		{
+		aol: {
 			name:              "Aol.com",
 			keys:              [".aol.com"],
 			calendar:          "https://caldav.aol.com/",
 			contact:           "https://carddav.aol.com/",
 			checkCredentials:  "https://caldav.aol.com/"
 		},
-		{
+		lsmat: {
 			name:              "Lms.at",
 			keys:              [".lms.at/", "//lms.at/"],
 			checkCredentials:  "https://lms.at/xocal-dav/"
 		},
-		{
+		mailboxorg: {
 			name:              "Mailbox.org",
 			keys:              [".mailbox.org"],
 			checkCredentials:  "https://dav.mailbox.org/"
 		}
-	],
+	},
 
 	processScheme: function (scheme, type, username, prefix) {
 		"use strict";
@@ -191,7 +197,7 @@ var UrlSchemes = {
 	 */
 	resolveURL: function (url, username, type, forceScheme) {
 		"use strict";
-		var i, j, scheme, index, prefix, newURL, searchUrl, tmpUrl;
+		var i, j, scheme, index, prefix, newURL, searchUrl, tmpUrl, keys;
 		if (!url) {
 			url = "";
 		}
@@ -211,8 +217,9 @@ var UrlSchemes = {
 			return this.processScheme(scheme, type, username, tmpUrl || url);
 		}
 
-		for (i = 0; i < this.urlSchemes.length; i += 1) {
-			scheme = this.urlSchemes[i];
+		keys = Object.keys(this.urlSchemes);
+		for (i = 0; i < keys.length; i += 1) {
+			scheme = this.urlSchemes[keys[i]];
 			for (j = 0; j < scheme.keys.length; j += 1) {
 				index = searchUrl.indexOf(scheme.keys[j].toLowerCase());
 				if (index >= 0) {

--- a/service/javascript/utils/AuthManager.js
+++ b/service/javascript/utils/AuthManager.js
@@ -113,7 +113,7 @@ var AuthManager = (function () {
 			return userAuth.authToken;
 		},
 
-		checkAuth: function (userAuth, url) {
+		checkAuth: function (userAuth, url, urlScheme) {
 			Log.debug("AUTH CHECK STARTING.");
 			var path, future = new Future(), outerFuture = new Future();
 			//for OAuth: maybe need to refresh tokens.
@@ -121,7 +121,9 @@ var AuthManager = (function () {
 				return doOAuthCheck(userAuth); //no need for the other stuff.
 			}
 
-			path = UrlSchemes.resolveURL(url, userAuth.username, "checkCredentials");
+			if (urlScheme !== -1) { //-1 means already resolved.
+				path = UrlSchemes.resolveURL(url, userAuth.username, "checkCredentials", urlScheme); //force right url scheme here, too.
+			}
 			if (!path) {
 				path = url;
 			}

--- a/service/javascript/utils/AuthManager.js
+++ b/service/javascript/utils/AuthManager.js
@@ -113,7 +113,7 @@ var AuthManager = (function () {
 			return userAuth.authToken;
 		},
 
-		checkAuth: function (userAuth, url, urlScheme) {
+		checkAuth: function (userAuth, url, urlScheme, cdavConfig) {
 			Log.debug("AUTH CHECK STARTING.");
 			var path, future = new Future(), outerFuture = new Future();
 			//for OAuth: maybe need to refresh tokens.
@@ -127,7 +127,8 @@ var AuthManager = (function () {
 			if (!path) {
 				path = url;
 			}
-			future.nest(CalDav.checkCredentials({userAuth: userAuth, path: path}));
+			cdavConfig.path = path;
+			future.nest(CalDav.checkCredentials(cdavConfig));
 
 			future.then(function checkCredentialsCB() {
 				var result = checkResult(future), urlParser, authString;
@@ -144,7 +145,7 @@ var AuthManager = (function () {
 							Log.debug("Trying digest auth.");
 							userAuth.authToken = authString;
 							userAuth.digest.PROPFIND = authString;
-							future.nest(CalDav.checkCredentials({userAuth: userAuth, path: path}));
+							future.nest(CalDav.checkCredentials(cdavConfig));
 						} else {
 							Log.debug("CREDENTIALS ARE WRONG!!");
 							outerFuture.result = result;

--- a/service/javascript/utils/CalDav.js
+++ b/service/javascript/utils/CalDav.js
@@ -517,7 +517,7 @@ var CalDav = (function () {
 
 			future.then(function () {
 				var result = checkResult(future);
-				future.result = { returnValue: result.returnValue, data: result.body };
+				future.result = { returnValue: result.returnValue, returnCode: result.returnCode, data: result.body };
 			});
 
 			return future;

--- a/service/javascript/utils/CalDav.js
+++ b/service/javascript/utils/CalDav.js
@@ -333,7 +333,8 @@ var CalDav = (function () {
 					"Content-Type": "text/xml; charset=utf-8", //necessary
 					Connection: "keep-alive",
 					"User-Agent": "org.webosports.cdav-connector"
-				}
+				},
+				ignoreSSLCertificateErrors: params.ignoreSSLCertificateErrors,
 			};
 
 		Log.debug("Path: ", params.path);

--- a/service/javascript/utils/CalDav.js
+++ b/service/javascript/utils/CalDav.js
@@ -335,6 +335,7 @@ var CalDav = (function () {
 					"User-Agent": "org.webosports.cdav-connector"
 				},
 				ignoreSSLCertificateErrors: params.ignoreSSLCertificateErrors,
+				authCallback: params.authCallback
 			};
 
 		Log.debug("Path: ", params.path);
@@ -406,6 +407,7 @@ var CalDav = (function () {
 			options.headers.Depth = 0;
 			data = "<d:propfind xmlns:d=\"DAV:\"><d:prop><d:current-user-principal /></d:prop></d:propfind>";
 
+			delete options.authCallback; //make sure we don't run into endless loop. AuthManager might call checkCredentials.
 			future.nest(httpClient.sendRequest(options, data));
 			return future;
 		},

--- a/service/javascript/utils/ETag.js
+++ b/service/javascript/utils/ETag.js
@@ -108,7 +108,7 @@ var ETag = (function () {
 									entries.push(r);
 									stats.update += 1;
 								} else {
-									if (l.uploadFailed) { //retry upload if no change on server only.
+									if (l.uploadFailed > 0) { //retry upload if no change on server only.
 										l.doRetry = true;
 										entries.push(l);
 										//Log.debug("RETRY ALREADY ON SERVER => ", entries);
@@ -124,7 +124,7 @@ var ETag = (function () {
 						if (!found) {
 							//only delete if object is in same collection.
 							if (!l.calendarId || l.calendarId === currentCollectionId) {
-								if (l.uploadFailed) { //upload failed and not on server => probably was never on server
+								if (l.uploadFailed > 0) { //upload failed and not on server => probably was never on server
 									stats.retriesNecessary += 1;
 									l.doRetry = true;
 									entries.push(l);

--- a/service/javascript/utils/OAuth.js
+++ b/service/javascript/utils/OAuth.js
@@ -14,6 +14,9 @@ var OAuth = (function () {
 				data = "client_id=" + credObj.client_id + "&client_secret=" + credObj.client_secret + "&refresh_token=" + credObj.refresh_token + "&grant_type=refresh_token",
 				options = { method: "POST", headers: {"Content-Type": "application/x-www-form-urlencoded"}};
 
+			//in theory we would have to get ignoreSSLErrors here somewhere and put that into options.
+			//Don't want to do that right now. Also it's just a work around that should go away someday.
+
 			//fill host and stuff.
 			httpClient.parseURLIntoOptions(credObj.refresh_url, options);
 

--- a/service/javascript/utils/httpClient.js
+++ b/service/javascript/utils/httpClient.js
@@ -14,7 +14,6 @@ var httpClient = (function () {
 	var proxy = {port: 0, host: "", valid: false},
 		httpsProxy = {port: 0, host: "", valid: false},
 		globalReqNum = 0,
-		ignoreSSLCertificateErrors = {},
 		retries = {};
 
 	function setProxy(proxyString, inProxy) {
@@ -74,7 +73,7 @@ var httpClient = (function () {
 		options.prefix = options.protocol + "//" + options.headers.host + ":" + options.port;
 		options.originalUrl = inUrl;
 
-		if (ignoreSSLCertificateErrors[options.host] && options.protocol === "https:") {
+		if (options.ignoreSSLCertificateErrors && options.protocol === "https:") {
 			options.rejectUnauthorized = false;
 			options.requestCert = true;
 		}
@@ -428,12 +427,6 @@ var httpClient = (function () {
 
 		parseURLIntoOptions: function (inUrl, options) {
 			return parseURLIntoOptionsImpl(inUrl, options);
-		},
-
-		setIgnoreSSLCertificateErrorsForHost: function (inUrl, value) {
-			var tmpOptions = {};
-			parseURLIntoOptionsImpl(inUrl, tmpOptions);
-			ignoreSSLCertificateErrors[tmpOptions.host] = value;
 		}
 	};
 }());

--- a/service/javascript/utils/httpClient_legacy.js
+++ b/service/javascript/utils/httpClient_legacy.js
@@ -409,10 +409,6 @@ var httpClient = (function () {
 
 		parseURLIntoOptions: function (inUrl, options) {
 			return parseURLIntoOptionsImpl(inUrl, options);
-		},
-
-		setIgnoreSSLCertificateErrorsForHost: function () {
-			Log.log("setIgnoreSSLCertificateErrorsForHost not supported for legacy http client.");
 		}
 	};
 }());

--- a/service/javascript/utils/httpClient_legacy.js
+++ b/service/javascript/utils/httpClient_legacy.js
@@ -133,7 +133,7 @@ var httpClient = (function () {
 		}
 	}
 
-	function sendRequestImpl(options, data, retry, origin) {
+	function sendRequestImpl(options, data, retry, origin, authretry) {
 		var body = new Buffer(0),
 			future = new Future(),
 			httpClient,
@@ -221,7 +221,8 @@ var httpClient = (function () {
 				returnCode: res.statusCode,
 				body: options.binary ? body : body.toString("utf8"),
 				headers: res.headers,
-				uri: options.prefix + options.path
+				uri: options.prefix + options.path,
+				method: options.method
 			};
 			if (options.path.indexOf(":/") >= 0) {
 				result.uri = options.path; //path already was complete, maybe because of proxy usage.
@@ -259,6 +260,21 @@ var httpClient = (function () {
 				result.parsedBody = xml.xmlstr2json(body.toString("utf8"));
 				Log.log_calDavParsingDebug("Parsed Body: ", result.parsedBody);
 				future.result = result;
+			} else if (res.statusCode === 401 && typeof options.authCallback === "function") {
+				future.nest(options.authCallback(result));
+
+				future.then(function authFailureCBResultHandling() {
+					var cbResult = future.result;
+					if (cbResult.returnValue === true && !authretry) {
+						if (cbResult.newAuthHeader) {
+							options.headers.Authorization = cbResult.newAuthHeader;
+						}
+						Log.debug("Retrying request with new auth data.");
+						future.nest(sendRequestImpl(options, data, 0, origin, true)); //retry request once with new auth.
+					} else {
+						future.result = result; //just give back the old, failed, result non the less?
+					}
+				});
 			} else {
 				future.result = result;
 			}

--- a/service/javascript/version.js
+++ b/service/javascript/version.js
@@ -1,1 +1,1 @@
-var PackageVersion = "0.3.20";
+var PackageVersion = "0.3.22";

--- a/service/javascript/version.js
+++ b/service/javascript/version.js
@@ -1,1 +1,1 @@
-var PackageVersion = "0.3.22";
+var PackageVersion = "0.3.23";


### PR DESCRIPTION
o fix for account creation and URL resolving that required username in URL.
o hot-fix for account creation with known-server-templates. Accounts created with 0.3.20 might stop working after this version. So please consider recreation if you created an account with 0.3.20.
o App: stats and status display improvements
o refresh Auth on 401 errors for OAuth and Digest Auth
o reworked ignoreSSLCertificateErrors
o Prevent unnecessary downloads of etags if we see unrecoverable download errors for single items like 404.

Signed-off-by: Achim Königs <garfonso@mobo.info>