### PR TITLE
Add additional permissions for apps

### DIFF
--- a/accounts-enyo/account-template.json
+++ b/accounts-enyo/account-template.json
@@ -3,16 +3,25 @@
     "loc_name": "C+DAV Connector",
     "readPermissions": [
         "org.webosports.cdav.service",
+        "org.webosports.app.contacts",
+        "org.webosports.app.messaging",
         "com.palm.service.contacts",
         "com.palm.service.contacts.linker",
-        "org.webosports.app.contacts",		
-        "com.palm.app.contacts"
+        "com.palm.imlibpurple",		
+        "com.palm.app.contacts",
+        "com.palm.app.messaging",
+        "com.palm.app.calendar",
+        "com.palm.app.email"
     ],
     "writePermissions": [
         "org.webosports.cdav.service",
+        "org.webosports.app.contacts",
+        "org.webosports.app.messaging",
         "com.palm.app.accounts",
-        "org.webosports.app.contacts",		
-        "com.palm.app.contacts"
+        "com.palm.app.contacts",
+        "com.palm.app.messaging",
+        "com.palm.app.calendar",
+        "com.palm.app.email"
     ],
     "validator": {
         "address": "palm://org.webosports.cdav.service/checkCredentials",

--- a/accounts-google-mojo/account-template.json
+++ b/accounts-google-mojo/account-template.json
@@ -3,16 +3,25 @@
 	"loc_name": "Google C+DAV",
 	"readPermissions": [
 		"org.webosports.cdav.service",
+		"org.webosports.app.contacts",
+		"org.webosports.app.messaging",
 		"com.palm.service.contacts",
 		"com.palm.service.contacts.linker",
-		"org.webosports.app.contacts",
-		"com.palm.app.contacts"
+		"com.palm.imlibpurple",		
+		"com.palm.app.contacts",
+		"com.palm.app.messaging",
+		"com.palm.app.calendar",
+		"com.palm.app.email"
 	],
 	"writePermissions": [
 		"org.webosports.cdav.service",
-		"com.palm.app.accounts",
 		"org.webosports.app.contacts",
-		"com.palm.app.contacts"
+		"org.webosports.app.messaging",
+		"com.palm.app.accounts",
+		"com.palm.app.contacts",
+		"com.palm.app.messaging",
+		"com.palm.app.calendar",
+		"com.palm.app.email"
 	],
 	"validator": {
 		"address": "palm://org.webosports.cdav.service/checkCredentials",

--- a/accounts-google/account-template.json
+++ b/accounts-google/account-template.json
@@ -3,16 +3,25 @@
 	"loc_name": "Google C+DAV",
 	"readPermissions": [
 		"org.webosports.cdav.service",
+		"org.webosports.app.contacts",
+		"org.webosports.app.messaging",
 		"com.palm.service.contacts",
 		"com.palm.service.contacts.linker",
-		"org.webosports.app.contacts",
-		"com.palm.app.contacts"
+		"com.palm.imlibpurple",		
+		"com.palm.app.contacts",
+		"com.palm.app.messaging",
+		"com.palm.app.calendar",
+		"com.palm.app.email"
 	],
 	"writePermissions": [
 		"org.webosports.cdav.service",
-		"com.palm.app.accounts",
 		"org.webosports.app.contacts",
-		"com.palm.app.contacts"
+		"org.webosports.app.messaging",
+		"com.palm.app.accounts",
+		"com.palm.app.contacts",
+		"com.palm.app.messaging",
+		"com.palm.app.calendar",
+		"com.palm.app.email"
 	],
 	"validator": {
 		"address": "palm://org.webosports.cdav.service/checkCredentials",

--- a/accounts-icloud/account-template.json
+++ b/accounts-icloud/account-template.json
@@ -3,16 +3,25 @@
 	"loc_name": "iCloud C+DAV",
 	"readPermissions": [
 		"org.webosports.cdav.service",
+		"org.webosports.app.contacts",
+		"org.webosports.app.messaging",
 		"com.palm.service.contacts",
 		"com.palm.service.contacts.linker",
-		"org.webosports.app.contacts",
-		"com.palm.app.contacts"
+		"com.palm.imlibpurple",		
+		"com.palm.app.contacts",
+		"com.palm.app.messaging",
+		"com.palm.app.calendar",
+		"com.palm.app.email"
 	],
 	"writePermissions": [
 		"org.webosports.cdav.service",
-		"com.palm.app.accounts",
 		"org.webosports.app.contacts",
-		"com.palm.app.contacts"
+		"org.webosports.app.messaging",
+		"com.palm.app.accounts",
+		"com.palm.app.contacts",
+		"com.palm.app.messaging",
+		"com.palm.app.calendar",
+		"com.palm.app.email"
 	],
 	"validator": "palm://org.webosports.cdav.service/checkCredentials",
 	"onCredentialsChanged": "palm://org.webosports.cdav.service/onCredentialsChanged",

--- a/accounts-yahoo/account-template.json
+++ b/accounts-yahoo/account-template.json
@@ -3,16 +3,25 @@
 	"loc_name": "Yahoo C+DAV",
 	"readPermissions": [
 		"org.webosports.cdav.service",
+		"org.webosports.app.contacts",
+		"org.webosports.app.messaging",
 		"com.palm.service.contacts",
 		"com.palm.service.contacts.linker",
-		"org.webosports.app.contacts",
-		"com.palm.app.contacts"
+		"com.palm.imlibpurple",		
+		"com.palm.app.contacts",
+		"com.palm.app.messaging",
+		"com.palm.app.calendar",
+		"com.palm.app.email"
 	],
 	"writePermissions": [
 		"org.webosports.cdav.service",
-		"com.palm.app.accounts",
 		"org.webosports.app.contacts",
-		"com.palm.app.contacts"
+		"org.webosports.app.messaging",
+		"com.palm.app.accounts",
+		"com.palm.app.contacts",
+		"com.palm.app.messaging",
+		"com.palm.app.calendar",
+		"com.palm.app.email"
 	],
 	"validator": "palm://org.webosports.cdav.service/checkCredentials",
 	"onCredentialsChanged": "palm://org.webosports.cdav.service/onCredentialsChanged",

--- a/accounts/account-template.json
+++ b/accounts/account-template.json
@@ -3,16 +3,25 @@
     "loc_name": "C+DAV Connector",
     "readPermissions": [
         "org.webosports.cdav.service",
+        "org.webosports.app.contacts",
+        "org.webosports.app.messaging",
         "com.palm.service.contacts",
         "com.palm.service.contacts.linker",
-        "org.webosports.app.contacts",
-        "com.palm.app.contacts"
+        "com.palm.imlibpurple",		
+        "com.palm.app.contacts",
+        "com.palm.app.messaging",
+        "com.palm.app.calendar",
+        "com.palm.app.email"
     ],
     "writePermissions": [
         "org.webosports.cdav.service",
-        "com.palm.app.accounts",
         "org.webosports.app.contacts",
-        "com.palm.app.contacts"
+        "org.webosports.app.messaging",
+        "com.palm.app.accounts",
+        "com.palm.app.contacts",
+        "com.palm.app.messaging",
+        "com.palm.app.calendar",
+        "com.palm.app.email"
     ],
     "validator": {
         "address": "palm://org.webosports.cdav.service/checkCredentials",


### PR DESCRIPTION
To solve things like:
Aug 30 21:50:36 mako ls-hubd[841]: Permission denied!
com.palm.app.calendar is not specified in template
org.webosports.cdav.account.google writePermissions
Aug 30 21:50:36 mako
ls-hubd[841]: Error: Permission denied! com.palm.app.calendar is not
specified in template org.webosports.cdav.account.google
writePermissions

While trying to add an account from com.palm.app.calendar app for example

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>