### PR TITLE
Change internetConfidence to true

### DIFF
--- a/service/javascript/assistants/onenabledassistant.js
+++ b/service/javascript/assistants/onenabledassistant.js
@@ -43,7 +43,7 @@ var OnEnabled = Class.create(Sync.EnabledAccountCommand, {
 							explicit: false //should delete this after one time run?
 						},
 						requirements: {
-							internetConfidence: "fair"
+							internetConfidence: true
 						},
 						schedule: {
 							//start in one minute.

--- a/service/javascript/assistants/syncassistant.js
+++ b/service/javascript/assistants/syncassistant.js
@@ -1400,7 +1400,7 @@ var SyncAssistant = Class.create(Sync.SyncCommand, {
 					.setPersist(true)
 					.setReplace(true)
 					.setPower(true) //prevent narcolepsy
-					.setRequirements({ internetConfidence: "fair" })
+					.setRequirements({ internetConfidence: true })
 					.setTrigger("fired", "palm://com.palm.db/watch", queryParams)
 					.setCallback("palm://" + this.controller.service.name + "/" + this.controller.config.name,
 								 { accountId: this.client.clientId });


### PR DESCRIPTION
As per new OSE ActivityManager schema, the value needs to be a boolean, so changing it to true.
Fixes "If 'internetConfidence' requirement is specified, the only legal value is 'true'"

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>