### PR TITLE
org.webosports.service.cdav.role.json: Fix duplicate "js" id for LS2

### DIFF
--- a/files/sysbus/org.webosports.service.cdav.role.json
+++ b/files/sysbus/org.webosports.service.cdav.role.json
@@ -1,7 +1,7 @@
 {
+    "appId": "org.webosports.service.cdav",
     "allowedNames": ["org.webosports.service.cdav"],
     "type": "regular",
-    "exeName": "js",
     "permissions": [
         {
             "inbound": ["*"],


### PR DESCRIPTION
"exeName": "js" is no longer required for LS2 in webOS OSE, and will lead to the following error:

Dec 6 09:02:38 qemux86-64 user.warn ls-hubd: [] [pmlog] ls-hubd LSHUB_ROLE_EXISTS {} Role already exists for id: "js"

This has been addressed by giving (NodeJS) services an appId it seems, so following that practice as well for our own NodeJS services.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>