### PR TITLE
org.webosports.service.cdav.perm.json: Fix permissions for getSystemT…

### DIFF
--- a/files/sysbus/org.webosports.service.cdav.perm.json
+++ b/files/sysbus/org.webosports.service.cdav.perm.json
@@ -3,6 +3,7 @@
         "services",
         "activities.manage",
         "applications.internal",
-        "database.internal"
+        "database.internal",
+        "time.query"
     ]
 }


### PR DESCRIPTION
…ime call

Solves: 2021-11-13T22:47:53.063873Z [342.381017709] user.err ports.service.cdav [] legacy-log  Error: palm://com.palm.systemservice/time/getSystemTime {"subscribe":false}: Denied method call "getSystemTime" for category "/time"     at Object.create (/usr/palm/frameworks/foundations/version/1.0/node_module.js:1:1309)     at /usr/palm/frameworks/foundations/version/1.0/node_module.js:1:35380     at Future.<anonymous> (/usr/palm/frameworks/foundations/version/1.0/node_module.js:1:10981)     at Timeout.d [as _onTimeout] (/usr/palm/frameworks/foundations/version/1.0/node_module.js:1:15961)     at listOnTimeout (internal/timers.js:554:17)     at processTimers (internal/timers.js:497:7)

Which makes C+Dav sync work again :)

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>