### PR TITLE
org.webosports.service.contacts.carddav: Migrate to Enhanced ACG

### DIFF
--- a/app-enyo/appinfo.json
+++ b/app-enyo/appinfo.json
@@ -4,8 +4,9 @@
 	"vendor": "WebOS Ports",
 	"type": "web",
 	"main": "index.html",
+	"trustLevel": "trusted",
 	"title": "C+DAV Sync App",
 	"icon": "images/caldav-1024.png",
 	"uiRevision": 2,
-	"requiredPermissions": ["services", "applications", "applications.internal", "activities.manage", "database.internal", "settings"]
+	"requiredPermissions": ["cdav-service.operation", "activity.operation", "database.operation"]
 }

--- a/files/sysbus/org.webosports.service.cdav.api.json
+++ b/files/sysbus/org.webosports.service.cdav.api.json
@@ -1,5 +1,5 @@
 {
-    "services": [
+    "cdav-service.operation": [
         "org.webosports.service.cdav/checkCredentials",
         "org.webosports.service.cdav/onCredentialsChanged",
         "org.webosports.service.cdav/onContactsCreate",

--- a/files/sysbus/org.webosports.service.cdav.perm.json
+++ b/files/sysbus/org.webosports.service.cdav.perm.json
@@ -1,9 +1,8 @@
 {
     "org.webosports.service.cdav": [
-        "services",
-        "activities.manage",
-        "applications.internal",
-        "database.internal",
+        "cdav-service.operation",
+        "activity.operation",
+        "database.operation",
         "time.query"
     ]
 }

--- a/files/sysbus/org.webosports.service.cdav.role.json
+++ b/files/sysbus/org.webosports.service.cdav.role.json
@@ -1,6 +1,7 @@
 {
     "appId": "org.webosports.service.cdav",
     "allowedNames": ["org.webosports.service.cdav"],
+    "trustLevel" : "oem",
     "type": "regular",
     "permissions": [
         {


### PR DESCRIPTION
In order to be able to use latest components from upstream webOS OSE.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
