### PR TITLE
org.webosports.service.contacts.carddav: Add ACG groups file

### DIFF
--- a/files/sysbus/org.webosports.service.cdav.groups.json
+++ b/files/sysbus/org.webosports.service.cdav.groups.json
@@ -1,0 +1,4 @@
+{
+ "allowedNames": ["org.webosports.service.cdav"],
+ "cdav-service.operation": ["dev"]
+}


### PR DESCRIPTION
Fixes:

WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg: Found 34 group(s) that appear only in api-permissions.d, consider define them in groups.d
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg: === LIST BEGIN: Groups used in api-permissions.d but not defined in groups.d ===
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg:   cdav-service.operation