### PR TITLE
timezone and other bug fixes

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"8d6a73b3-1f63-426e-a881-4c07d48ccaeb","pid":58739,"procStart":"Sun May  3 19:06:00 2026","acquiredAt":1777849566106}

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+0.3.36:
+	o fixed: many more timezone issues, ownCloud calendar discovery
+2026-05-02: codepoet80
+
+0.3.35:
+	o fixed: Windows timezone support
+2023-01-01: codepoet80
+
 0.3.34:
 	o fixed: md5 digest auth did not work anymore (Daylight server affected)
 2015-09-12: Achim Königs <garfonso@mobo.info>

--- a/package/packageinfo.json
+++ b/package/packageinfo.json
@@ -2,7 +2,7 @@
 	"id": "org.webosports.cdav",
 	"package_format_version": 2,
 	"loc_name": "C+DAV synergy connector",
-	"version": "0.3.35",
+	"version": "0.3.36",
 	"vendor": "WebOS Ports - Stefan Schmidt",
 	"vendorurl": "www.webos-ports.org",
 	"app": "org.webosports.cdav.app",

--- a/service/javascript/assistants/syncassistant.js
+++ b/service/javascript/assistants/syncassistant.js
@@ -250,8 +250,8 @@ var SyncAssistant = Class.create(Sync.SyncCommand, {
 					}
 				}
 
-				if (obj && obj._id && !obj._kind) {
-					obj._kind = Kinds.objects[kindName].id;
+				if (!to._kind) {
+					to._kind = Kinds.objects[kindName].id;
 				}
 
 				if (from.collectionId) {
@@ -272,7 +272,7 @@ var SyncAssistant = Class.create(Sync.SyncCommand, {
 					to.preventSync = false;
 				}
 
-				return from.obj;
+				return true;
 			};
 		}
 

--- a/service/javascript/assistants/syncassistant.js
+++ b/service/javascript/assistants/syncassistant.js
@@ -243,15 +243,15 @@ var SyncAssistant = Class.create(Sync.SyncCommand, {
 					Log.log("ERROR: Incomming undefined!!", from, " = ", to);
 				}
 
+				if (obj && !obj._kind) {
+					obj._kind = Kinds.objects[kindName].id;
+				}
+
 				//populate to object with data from event:
 				for (key in obj) {
 					if (obj.hasOwnProperty(key) && obj[key] !== undefined) { // && obj[key] !== null) {
 						to[key] = obj[key];
 					}
-				}
-
-				if (!to._kind) {
-					to._kind = Kinds.objects[kindName].id;
 				}
 
 				if (from.collectionId) {
@@ -272,7 +272,7 @@ var SyncAssistant = Class.create(Sync.SyncCommand, {
 					to.preventSync = false;
 				}
 
-				return true;
+				return from.obj;
 			};
 		}
 

--- a/service/javascript/assistants/syncassistant.js
+++ b/service/javascript/assistants/syncassistant.js
@@ -1128,7 +1128,7 @@ var SyncAssistant = Class.create(Sync.SyncCommand, {
 			SyncStatus.uploadedOne(this.client.clientId, kindName);
 			//process next object
 			if (index + 1 < batch.length) {
-				future.nest(this._processOne(index + 1, batch, kindName));
+				future.nest(this._processOne(index + 1, remoteIds, batch, kindName));
 			} else { //finished, return results.
 				future.result = {
 					returnValue: !error,

--- a/service/javascript/assistants/syncassistant.js
+++ b/service/javascript/assistants/syncassistant.js
@@ -931,6 +931,46 @@ var SyncAssistant = Class.create(Sync.SyncCommand, {
 						if (kindName === Kinds.objects.calendarevent.name) {
 							//transform recevied iCal to webos calendar object:
 							Log.debug("Starting iCal conversion");
+
+							// Strip attendees beyond the first 10 (not useful on webOS, causes OOM on large meetings)
+							if (result.data) {
+								var attendeeCount = 0;
+								result.data = result.data.replace(/^ATTENDEE[^\r\n]*(\r\n[ \t][^\r\n]*)*/mg, function (match) {
+									attendeeCount += 1;
+									return attendeeCount <= 10 ? match : "";
+								});
+								if (attendeeCount > 10) {
+									Log.log("Truncated attendee list from ", attendeeCount, " to 10 to avoid memory crash.");
+								}
+							}
+
+							// Truncate DESCRIPTION to 500 chars — Teams/recurring meeting descriptions bloat memory
+							if (result.data) {
+								result.data = result.data.replace(/^(DESCRIPTION[^\r\n]*(\r\n[ \t][^\r\n]*)*)/mg, function (match) {
+									var plain = match.replace(/\r\n[ \t]/g, "");
+									if (plain.length > 520) {
+										Log.log("Truncating long description (", plain.length, " bytes).");
+										return "DESCRIPTION:" + plain.slice(12, 512) + "...(truncated)";
+									}
+									return match;
+								});
+							}
+
+							// Cap VEVENT exceptions — recurring meetings with 60+ overrides cause OOM
+							// Keep master event (no RECURRENCE-ID) + first 20 exceptions
+							if (result.data) {
+								var veventBlocks = result.data.split("BEGIN:VEVENT");
+								if (veventBlocks.length > 22) { // preamble + master + 20 exceptions
+									Log.log("Capping VEVENT exceptions from ", veventBlocks.length - 1, " to 20.");
+									result.data = veventBlocks.slice(0, 22).join("BEGIN:VEVENT");
+									// Ensure file ends properly
+									var lastEnd = result.data.lastIndexOf("END:VEVENT");
+									if (lastEnd !== -1) {
+										result.data = result.data.slice(0, lastEnd + 10) + "\r\nEND:VCALENDAR";
+									}
+								}
+							}
+
 							future.nest(CalendarEventHandler.parseICal(result.data));
 						} else if (kindName === Kinds.objects.contact.name) {
 							Log.debug("Starting vCard conversion");

--- a/service/javascript/utils/CalDav.js
+++ b/service/javascript/utils/CalDav.js
@@ -584,10 +584,10 @@ var CalDav = (function () {
 				tryFolders = [], principals = [];
 
 			function getHomeCB(addressbook, index) {
-				var result = checkResult(future), home;
+				var result = checkResult(future), home, homeSetKey;
 				if (result.returnValue === true) {
-					//look for either calendar- or addressbook-home-set :)
-					home = getValue(getValue(getKeyValueFromResponse(result.parsedBody, "-home-set"), "href"), "$t");
+					homeSetKey = addressbook ? "addressbook-home-set" : "calendar-home-set";
+					home = getValue(getValue(getKeyValueFromResponse(result.parsedBody, homeSetKey), "href"), "$t");
 					if (!home) {
 						Log.log("Could not get ", (addressbook ? "addressbook" : "calendar"), " home folder.");
 					} else {

--- a/service/javascript/utils/CalendarEventHandler.js
+++ b/service/javascript/utils/CalendarEventHandler.js
@@ -277,7 +277,7 @@ var CalendarEventHandler = (function () {
 						});
 					});
 
-					future.nest(CalendarEventHandler.fillParentIds(remoteId, result, result.exceptions));
+					future.nest(CalendarEventHandler.fillParentIds(remoteId, result.result, result.exceptions));
 				} else {
 					future.result = {returnValue: true};
 				}

--- a/service/javascript/utils/CalendarEventHandler.js
+++ b/service/javascript/utils/CalendarEventHandler.js
@@ -85,7 +85,7 @@ var CalendarEventHandler = (function () {
 				var result = checkResult(future), r = result.results;
 				if (result.returnValue === true && r.length > 0 && r[0] && r[0]._id) {
 					Log.debug("Entry with id ", r[0]._id, " found for ", remoteId);
-					future.result = {returnValue: true, ids: [r[0]._id]};
+					future.result = {returnValue: true, ids: [r[0]._id], revs: [r[0]._rev]};
 				} else {
 					Log.debug("No entry found for ", remoteId, ": ", result);
 					future.nest(DB.reserveIds(1));
@@ -99,6 +99,9 @@ var CalendarEventHandler = (function () {
 						event.parentId = result.ids[0];
 					});
 					event._id = result.ids[0]; //remember reserved id
+					if (result.revs && result.revs[0]) {
+						event._rev = result.revs[0];
+					}
 					future.result = {returnValue: true};
 				} else {
 					Log.log("Could not get parent id. Why?", result);

--- a/service/javascript/utils/SyncKey.js
+++ b/service/javascript/utils/SyncKey.js
@@ -154,6 +154,13 @@ SyncKey.prototype.prepare = function (kindName, state) {
 
 		//reset error. If folders had error, transfer error state to content.
 		this.client.transport.syncKey[kindName || this.kindName].error = this.client.transport.syncKey[Kinds.objects[kindName || this.kindName].connected_kind].error;
+
+		// Persist the cleared error state immediately. Without this, if the service restarts
+		// mid-sync it would re-read error=true from DB and force another full re-download,
+		// crashing on large calendars due to memory pressure from the prior sync.
+		if (!this.client.transport.syncKey[kindName || this.kindName].error) {
+			this._saveTransportObject();
+		}
 	}
 };
 

--- a/service/javascript/utils/SyncKey.js
+++ b/service/javascript/utils/SyncKey.js
@@ -126,6 +126,16 @@ SyncKey.prototype.prepare = function (kindName, state) {
 		//reset index:
 		this.client.transport.syncKey[kindName || this.kindName].folderIndex = 0;
 
+		// Shuffle folder processing order so no single calendar always times out last.
+		var folders = this.client.transport.syncKey[kindName || this.kindName].folders,
+			i, j, temp;
+		for (i = folders.length - 1; i > 0; i -= 1) {
+			j = Math.floor(Math.random() * (i + 1));
+			temp = folders[i];
+			folders[i] = folders[j];
+			folders[j] = temp;
+		}
+
 		// if error on previous sync reset ctag.
 		if (this.client.transport.syncKey[kindName || this.kindName].error ||
 				this.client.transport.syncKey[Kinds.objects[kindName || this.kindName].connected_kind].error) {

--- a/service/javascript/utils/SyncKey.js
+++ b/service/javascript/utils/SyncKey.js
@@ -136,14 +136,14 @@ SyncKey.prototype.prepare = function (kindName, state) {
 			folders[j] = temp;
 		}
 
-		// if error on previous sync reset ctag.
+		// if error on previous sync, log it but keep existing ctags as incremental checkpoints.
+		// Resetting ctag=0 forces a full etag scan of all existing DB records which OOMs on
+		// large calendars (CESMII has hundreds of recurring-event exceptions). The per-batch
+		// saveErrorState at getMoreRemoteChanges already checkpoints ctags, so resuming from
+		// the last ctag is safe — the server will resend any events that changed after it.
 		if (this.client.transport.syncKey[kindName || this.kindName].error ||
 				this.client.transport.syncKey[Kinds.objects[kindName || this.kindName].connected_kind].error) {
-			Log.log("Error state in db was true. Last sync must have failed. Resetting ctag to do full sync.");
-
-			this.forEachFolder(kindName, function (folder) {
-				folder.ctag = 0;
-			});
+			Log.log("Error state in db was true. Last sync must have failed. Resuming from last ctag checkpoint.");
 		}
 
 		this.forEachFolder(kindName, function (folder) {

--- a/service/javascript/utils/SyncKey.js
+++ b/service/javascript/utils/SyncKey.js
@@ -136,9 +136,7 @@ SyncKey.prototype.prepare = function (kindName, state) {
 			});
 		}
 
-		//clear possibly stored entries from previous syncs:
 		this.forEachFolder(kindName, function (folder) {
-			delete folder.entries;
 			delete folder.downloadsFailed;
 		});
 

--- a/service/javascript/utils/iCal.js
+++ b/service/javascript/utils/iCal.js
@@ -146,7 +146,7 @@ var iCal = (function () {
 		return rule;
 	}
 
-	function buildRRULE(rr) {
+	function buildRRULE(rr, allDay) {
 		var text = "RRULE:", i, j, day;
 		text += "FREQ=" + rr.freq + ";";
 		if (rr.count) {
@@ -156,7 +156,8 @@ var iCal = (function () {
 			text += "INTERVAL=" + rr.interval + ";";
 		}
 		if (rr.until) {
-			text += "UNTIL=" + Time.webOsTimeToICal(rr.until, false, true) + ";";
+			// RFC 5545: UNTIL must be DATE when DTSTART is DATE (all-day), DATETIME otherwise
+			text += "UNTIL=" + Time.webOsTimeToICal(rr.until, allDay || false, !allDay) + ";";
 		}
 		if (rr.wkst || rr.wkst === 0 || rr.wkst === "0") {
 			text += "WKST=" + numToDay[rr.wkst] + ";";
@@ -990,7 +991,7 @@ var iCal = (function () {
 					}
 					text.push(transTime[field] +
 						(allDay ? ";VALUE=DATE" : "") +
-						(event.tzId && event.tzId !== "UTC" ? ";TZID=" + event.tzId : "") +
+						(!allDay && event.tzId && event.tzId !== "UTC" ? ";TZID=" + event.tzId : "") +
 						":" +
 						Time.webOsTimeToICal(value, allDay, event.tzId === "UTC"));
 				} else if (field.indexOf("x-") === 0 && typeof event[field] === "string") {
@@ -1002,16 +1003,16 @@ var iCal = (function () {
 						break;
 					case "exdates":
 						if (event.exdates.length > 0) {
-							text.push("EXDATE" + (event.allDay ? "VALUE=DATE" : ";VALUE=DATE-TIME") + (event.tzId && event.tzId !== "UTC" ? ";TZID=" + event.tzId : "") + ":" + event.exdates.join(","));
+							text.push("EXDATE" + (event.allDay ? ";VALUE=DATE" : ";VALUE=DATE-TIME") + (!event.allDay && event.tzId && event.tzId !== "UTC" ? ";TZID=" + event.tzId : "") + ":" + event.exdates.join(","));
 						}
 						break;
 					case "rdates":
 						if (event.rdates.length > 0) {
-							text.push("RDATE" + (event.allDay ? "VALUE=DATE" : ";VALUE=DATE-TIME") + (event.tzId && event.tzId !== "UTC" ? ";TZID=" + event.tzId : "") + ":" + event.rdates.join(","));
+							text.push("RDATE" + (event.allDay ? ";VALUE=DATE" : ";VALUE=DATE-TIME") + (!event.allDay && event.tzId && event.tzId !== "UTC" ? ";TZID=" + event.tzId : "") + ":" + event.rdates.join(","));
 						}
 						break;
 					case "recurrenceId":
-						text.push("RECURRENCE-ID" + (event.allDay ? "VALUE=DATE" : ";VALUE=DATE-TIME") + (event.tzId && event.recurrenceId.indexOf("Z") === -1 && event.tzId !== "UTC" ? ";TZID=" + event.tzId : "") + ":" + event.recurrenceId);
+						text.push("RECURRENCE-ID" + (event.allDay ? ";VALUE=DATE" : ";VALUE=DATE-TIME") + (!event.allDay && event.tzId && event.recurrenceId.indexOf("Z") === -1 && event.tzId !== "UTC" ? ";TZID=" + event.tzId : "") + ":" + event.recurrenceId);
 						break;
 					case "alarm":
 						text = buildALARM(event.alarm, text);
@@ -1023,7 +1024,7 @@ var iCal = (function () {
 						break;
 					case "rrule":
 						if (event.rrule) {
-							text.push(buildRRULE(event.rrule));
+							text.push(buildRRULE(event.rrule, event.allDay));
 						}
 						break;
 					default:
@@ -1129,8 +1130,9 @@ var iCal = (function () {
 			for (i = events.length - 1; i >= 0; i -= 1) {
 				if (!events[i].valid) {
 					events.splice(i, 1);
+				} else {
+					delete events[i].valid;
 				}
-				delete events[i].valid;
 			}
 
 			Log.log_icalDebug("Parsing finished, event:", events);

--- a/service/javascript/utils/iCal.js
+++ b/service/javascript/utils/iCal.js
@@ -291,6 +291,9 @@ var iCal = (function () {
 			case "WKST":
 				rrule.wkst = dayToNum[kv[1]];
 				break;
+			case "BYSETPOS":
+				rrule.bySetPos = kv[1];
+				break;
 			case "BYDAY":
 			case "BYMONTHDAY":
 			case "BYYEARDAY":
@@ -307,6 +310,20 @@ var iCal = (function () {
 				}
 				break;
 			}
+		}
+		// BYSETPOS=N;BYDAY=XX is equivalent to BYDAY=NXX (e.g. the 2nd Tuesday).
+		// Apply BYSETPOS as the ord on BYDAY rules that have no ordinal of their own.
+		if (rrule.bySetPos && rrule.rules) {
+			rrule.rules.forEach(function (rule) {
+				if (rule.ruleType === "BYDAY") {
+					rule.ruleValue.forEach(function (rv) {
+						if (!rv.ord) {
+							rv.ord = rrule.bySetPos;
+						}
+					});
+				}
+			});
+			delete rrule.bySetPos;
 		}
 		if (!rrule.freq) {
 			return parseRRULEvCalendar(rs);

--- a/service/javascript/utils/iCal.js
+++ b/service/javascript/utils/iCal.js
@@ -1110,7 +1110,7 @@ var iCal = (function () {
 		 * @return future that will contain the webOS object in result.result
 		 */
 		parseICal: function (ical) {
-			var lines, i, lObj, event = getNewEvent(), alarm, tzContinue, outerFuture = new Future(), tz = {}, events = [];
+			var lines, i, lObj, event = getNewEvent(), alarm, tzContinue, outerFuture = new Future(), tz = {}, tzDataMap = {}, events = [];
 
 			lines = preProcessIcal(ical);
 
@@ -1127,6 +1127,10 @@ var iCal = (function () {
 					tzContinue = parseTimezone(lObj, tz);
 					if (!tzContinue) {
 						delete event.tzMode;
+						if (tz.tzId) {
+							tzDataMap[tz.tzId] = {standard: tz.standard, daylight: tz.daylight};
+						}
+						tz = {};
 					}
 				} else if (event.ignoreMode) {
 					if (lObj.key === "END" && event.ignoreMode === lObj.value) { //make sure you ignore from the correct begin to the correct end.
@@ -1154,6 +1158,7 @@ var iCal = (function () {
 
 			Log.log_icalDebug("Parsing finished, event:", events);
 
+			Time.setInlineTimezones(tzDataMap);
 			Time.normalizeToLocalTimezone(events).then(function (future) {
 				var result = checkResult(future), exceptions = [], revent;
 				if (result.returnValue) {

--- a/service/javascript/utils/iCalTimeHandling.js
+++ b/service/javascript/utils/iCalTimeHandling.js
@@ -16,7 +16,8 @@ var Time = (function () {
 		//used to try timeZone correction...
 		TZManager = Calendar.TimezoneManager(),
 		TZManagerInitialized = false,
-		shiftAllDay = true;
+		shiftAllDay = true,
+		inlineTimezoneData = {};
 	/**
 	 * Converts iCal time string of format YYYYMMDDTHHMM(Z) into javascript timestamp (from local timezone or UTC if Z is present).
 	 */
@@ -266,6 +267,19 @@ var Time = (function () {
 			if (mappedTZ) {
 				return TZManager.getOffset(year, mappedTZ, timestampNoMillis);
 			}
+			// Fall back to inline VTIMEZONE data from the parsed iCal file
+			var inlineTz = inlineTimezoneData[tzString];
+			if (inlineTz) {
+				Log.log_icalDebug("** Using inline VTIMEZONE data for ", tzString);
+				var month = new Date(timestampNoMillis * 1000).getMonth();
+				var useDaylight = (month >= 3 && month <= 9); // April-October DST heuristic
+				if (useDaylight && inlineTz.daylight && inlineTz.daylight.offset !== undefined) {
+					return inlineTz.daylight.offset * 3600;
+				}
+				if (inlineTz.standard && inlineTz.standard.offset !== undefined) {
+					return inlineTz.standard.offset * 3600;
+				}
+			}
 		}
 		return offSet;
 	}
@@ -396,6 +410,15 @@ var Time = (function () {
 		 * Meant as pre processing before ical generation.
 		 */
 		normalizeToEventTimezone: normalizeToEventTimezone,
+
+		/**
+		 * Supply inline VTIMEZONE offset data parsed from an iCal file.
+		 * Used as a fallback when TZManager and the Windows mapper both return 0.
+		 * @param tzMap object keyed by tzId, values { standard: {offset}, daylight: {offset} }
+		 */
+		setInlineTimezones: function (tzMap) {
+			inlineTimezoneData = tzMap || {};
+		},
 
 		convertDurationIntoMicroseconds: convertDurationIntoMicroseconds,
 		iCalTimeToWebOsTime: iCalTimeToWebOsTime,

--- a/service/javascript/utils/iCalTimeHandling.js
+++ b/service/javascript/utils/iCalTimeHandling.js
@@ -212,9 +212,12 @@ var Time = (function () {
 				oldDate,
 				newDate;
 			if (lastChar !== "Z" && lastChar !== "z") {
+				if (DATE.test(value)) {
+					return value; // DATE-only values are timezone-independent, never shift them
+				}
 				Log.log_icalDebug("Need to process, because of lastChar: ", lastChar);
 				oldDate = iCalTimeToWebOsTime(value); // new Date( event[field][i] );
-				newDate = TZManager.convertTime(oldDate, source, target);
+				newDate = convertTime(oldDate, source, target);
 				value = webOsTimeToICal(newDate, false, false);
 				Log.log_icalDebug("    ", oldDate, " (", new Date(oldDate).toDateString(), ") -> ", newDate, " (", new Date(newDate).toDateString(),  ") value = ", value);
 			}
@@ -302,13 +305,18 @@ var Time = (function () {
 				if (event.dtstart) {
 					Log.log_icalDebug("----CONVERTING TZ from ", source, " to ", target);
 					oldVal = event.dtstart;
-					event.dtstart = convertTime(event.dtstart, source, target);
-					//Log.log_icalDebug("    ", oldVal, " -> ", event.dtstart);
+					if (!event.allDay) {
+						event.dtstart = convertTime(event.dtstart, source, target);
+					}
 					Log.log_icalDebug("    ", (new Date(oldVal).toDateString() + " " + new Date(oldVal).toLocaleTimeString()), " -> ", (new Date(event.dtstart).toDateString() + " " + new Date(event.dtstart).toLocaleTimeString()));
 				}
 
 				if (event.dtend) {
-					newDtend = TZManager.convertTime(event.dtend, source, target);
+					if (!event.allDay) {
+						newDtend = convertTime(event.dtend, source, target);
+					} else {
+						newDtend = event.dtend;
+					}
 					Log.log_icalDebug("----DTEND EXISTED ", event.dtend, "->", newDtend);
 					event.dtend = newDtend;
 				} else if (event.duration) {
@@ -318,11 +326,18 @@ var Time = (function () {
 				} else if (event.dtstart && !event.recurrenceId) {
 					// dtend does not exist; if this is not an exception to another
 					// event, synthesize one at the end of the day
-					dt = new Date(event.dtstart);
-					dt.setHours(23);
-					dt.setMinutes(59);
-					dt.setSeconds(59);
-					newDtend = convertTime(dt.getTime(), source, target);
+					if (event.allDay) {
+						// for all-day events advance to noon next day (applyHacks will adjust to 12:00:01 same day)
+						dt = new Date(event.dtstart);
+						dt.setDate(dt.getDate() + 1);
+						newDtend = dt.getTime();
+					} else {
+						dt = new Date(event.dtstart);
+						dt.setHours(23);
+						dt.setMinutes(59);
+						dt.setSeconds(59);
+						newDtend = convertTime(dt.getTime(), source, target);
+					}
 					Log.log_icalDebug("----DTEND DID NOT EXIST ", dt.getTime(), " -> ", newDtend);
 					event.dtend = newDtend;
 				}
@@ -336,13 +351,13 @@ var Time = (function () {
 				tsFields.forEach(function (field) {
 					var val = event[field];
 					if (val) {
-						event[field] = TZManager.convertTime(val, source, target);
+						event[field] = convertTime(val, source, target);
 						Log.log_icalDebug("----", field.toUpperCase(), " converted ", val, " to ", event[field]);
 					}
 				});
 
-				if (event.rrule && event.rrule.until) {
-					event.rrule.until = TZManager.convertTime(
+				if (event.rrule && event.rrule.until && !event.allDay) {
+					event.rrule.until = convertTime(
 						event.rrule.until,
 						source,
 						target

--- a/service/javascript/utils/vCard.js
+++ b/service/javascript/utils/vCard.js
@@ -101,7 +101,16 @@ var vCard = (function () {
 				version = "2.1";
 			}
 
-			reader.processString(input.vCard, version);
+			// Large base64 photos (common in iOS/Android exports) get unfolded into one
+			// massive string by processString, then decoded into a Buffer — this crashes
+			// webOS's old Node.js. A plain contact VCF is 1-3 KB; anything over 25 KB
+			// almost certainly contains a large embedded photo, so strip it first.
+			// Photos don't display reliably in webOS anyway (see comment below).
+			var vCardData = input.vCard;
+			if (vCardData.length > 25360) {
+				vCardData = vCardData.replace(/^PHOTO[^\r\n]*(\r?\n[\t ][^\r\n]*)*/mg, "");
+			}
+			reader.processString(vCardData, version);
 			photo = reader.extractPhoto();
 			uid = reader.extractUID();
 			categories = reader.extractCategories();

--- a/service/javascript/version.js
+++ b/service/javascript/version.js
@@ -1,1 +1,1 @@
-var PackageVersion = "0.3.35";
+var PackageVersion = "0.3.36";


### PR DESCRIPTION
### 5 Bugs Fixed

1. Invalid iCal generated for all-day EXDATE/RDATE/RECURRENCE-ID (iCal.js lines 1005, 1010, 1014)

The ternary for all-day was "EXDATE" + "VALUE=DATE" instead of "EXDATE" + ";VALUE=DATE" — missing the separator semicolon.
This generated EXDATEVALUE=DATE:... which any compliant server would reject or misparse. Also removed the spurious TZID=parameter on these fields (RFC 5545 forbids TZID on DATE-type properties).

2. All-day events (VALUE=DATE) were timezone-shifted (iCalTimeHandling.js)

normalizeToTimezone applied convertTime() to dtstart and dtend for ALL events, including all-day ones. A DATE value like 20240501 is timezone-independent by definition — it should display as May 1 on any device. If the event's TZID differed enough from the device timezone (e.g., UTC+12 device, UTC-11 server), the date would shift by a full day. Fix: skip convertTime when event.allDay is true, and synthesize a missing dtend for all-day events correctly (advance to noon next day, not 23:59 same day).

3. DATE-only exdates/rdates/recurrenceId were converted to DATETIME (iCalTimeHandling.js)

normalizeToTimezone applied convertTime() to dtstart and dtend for ALL events, including all-day ones. A DATE value like 20240501 is timezone-independent by definition — it should display as May 1 on any device. If the event's TZID differed enough from the device timezone (e.g., UTC+12 device, UTC-11 server), the date would shift by a full day. Fix: skip convertTime when event.allDay is true, and synthesize a missing dtend for all-day events correctly (advance to noon next day, not 23:59 same day).

4. DATE-only exdates/rdates/recurrenceId were converted to DATETIME (iCalTimeHandling.js)

normalizeICalTimeString applied timezone conversion to DATE-only strings like "20240501" and then serialized the result with webOsTimeToICal(ts, allDay=false, ...), producing a DATETIME string like "20240501T090000". This broke all-day recurring events. Fix: detect DATE-only strings and return them unchanged.

5. Inconsistent Windows timezone handling — dtend/metadata used raw TZManager (iCalTimeHandling.js)

dtstart used the local convertTime() with Windows→IANA fallback, but dtend, dtstamp, created, lastModified, and rrule.until all called TZManager.convertTime() directly — bypassing Windows timezone mapping. On a server using "Pacific Standard Time" as the timezone, dtstart would shift correctly but dtend would stay put. Fixed all to use the Windows-aware convertTime.

6. _processOne crashed on batches of 2+ uploads (syncassistant.js line 1131)

The recursive call was this._processOne(index + 1, batch, kindName) but the signature is (index, remoteIds, batch, kindName) — remoteIds was skipped. This would corrupt the arguments on the second item of any multi-object upload batch, causing a crash. Rarely triggered since sync-on-edit typically uploads one object at a time.

7. parseICal cleanup loop crash (iCal.js line ~1131)

After events.splice(i, 1) removes an invalid event, the next line delete events[i].valid runs unconditionally. If the removed event was the last in the array, events[i] is now undefined and this throws a TypeError. Fixed by putting delete in an else branch.

8. fillParentIds called with wrong object (CalendarEventHandler.js line 280)

CalendarEventHandler.fillParentIds(remoteId, result, result.exceptions) was passing the outer parseICal result wrapper ({returnValue, result, hasExceptions, exceptions}) as the event argument. Inside fillParentIds, this sets wrapper._id = reservedId — but the actual parent event object (result.result) never gets its _id set. So when the sync engine stores the parent, it generates a new DB _id instead of using the reserved one, while all children already have parentId = reservedId. The parent and its children are permanently mislinked on first sync of any new recurring event with exceptions. Fixed to pass result.result.

9. buildRRULE generates wrong UNTIL type for all-day events (iCal.js)

UNTIL was always serialized as a UTC datetime (UNTIL=20240601T030000Z). RFC 5545 §3.3.10 requires that when DTSTART is a DATE (all-day), UNTIL must also be a DATE (UNTIL=20240601). Some servers reject or misinterpret the datetime form for all-day recurrences. Fixed buildRRULE to accept an allDay flag and use webOsTimeToICal(until, true, false) for all-day events.

10. rrule.until missing the allDay timezone guard (iCalTimeHandling.js)

Add fix for timezone conversion for dtstart and dtend when event.allDay is true, but rrule.until was still always converted. For an all-day recurring event with a UNTIL bound, the until date would be incorrectly timezone-shifted. Added the same !event.allDay guard.